### PR TITLE
Added Checked In Count

### DIFF
--- a/packages/nextjs/app/page.tsx
+++ b/packages/nextjs/app/page.tsx
@@ -1,10 +1,16 @@
 "use client";
 
 import Link from "next/link";
+import { useScaffoldReadContract } from "../hooks/scaffold-eth/useScaffoldReadContract";
 import type { NextPage } from "next";
 import { BugAntIcon, MagnifyingGlassIcon } from "@heroicons/react/24/outline";
 
 const Home: NextPage = () => {
+  const { data: checkedInCounter, isLoading: isCheckedInCounterLoading } = useScaffoldReadContract({
+    contractName: "BatchRegistry",
+    functionName: "checkedInCounter",
+  });
+
   return (
     <>
       <div className="flex items-center flex-col flex-grow pt-10">
@@ -16,7 +22,11 @@ const Home: NextPage = () => {
           <p className="text-center text-lg">Get started by taking a look at your batch GitHub repository.</p>
           <p className="text-lg flex gap-2 justify-center">
             <span className="font-bold">Checked in builders count:</span>
-            <span>To Be Implemented</span>
+            {isCheckedInCounterLoading || checkedInCounter === undefined ? (
+              <span className="loading loading-spinner"></span>
+            ) : (
+              <span className="m-0 font-bold text-green-400">{checkedInCounter ? checkedInCounter.toString() : 0}</span>
+            )}
           </p>
         </div>
 


### PR DESCRIPTION
- Added real checked in count from the BatchRegistry contract.
  - Used `BatchRegistry` contract from `externalContracts`.
- Used a simple loader and green checked in count text to display the count.

## Description

The `checkedInCounter` of `BatchRegistry` contract is read using the `useScaffoldReadContract` function. 

`BatchRegistry` name is used based on the information declared in `externalContracts.ts`

In order to display the count a green text is added and a spinner loader is displayed until the count is loaded.

![image](https://github.com/user-attachments/assets/e30df8a2-510b-4ea5-9feb-89294b06b176)
![image](https://github.com/user-attachments/assets/60ec9c07-6242-4331-9be4-d6fe9d8fdea5)

## Additional Notes

- `checkedInCounter === undefined` condition is used with `isCheckedInCounterLoading` because at first the `isCheckedInCounterLoading` variable is false which created an unwanted state for the loader display. For example, the text followed this flow: 0 -> loader -> 5. This didn't feel like good UX, hence the solution.

## Related Issues

_Closes #5_

Address: 0x97d45F88468289ac299B79cF01bbB6f218c46230