### PR TITLE
Implemented number of checked in users functionality.

### DIFF
--- a/packages/nextjs/app/page.tsx
+++ b/packages/nextjs/app/page.tsx
@@ -3,8 +3,18 @@
 import Link from "next/link";
 import type { NextPage } from "next";
 import { BugAntIcon, MagnifyingGlassIcon } from "@heroicons/react/24/outline";
+import { useScaffoldReadContract } from "~~/hooks/scaffold-eth";
 
 const Home: NextPage = () => {
+  const {
+    data: checkedInNumber,
+    isLoading,
+    error: loadingError,
+  } = useScaffoldReadContract({
+    contractName: "BatchRegistry",
+    functionName: "checkedInCounter",
+  });
+
   return (
     <>
       <div className="flex items-center flex-col flex-grow pt-10">
@@ -16,7 +26,13 @@ const Home: NextPage = () => {
           <p className="text-center text-lg">Get started by taking a look at your batch GitHub repository.</p>
           <p className="text-lg flex gap-2 justify-center">
             <span className="font-bold">Checked in builders count:</span>
-            <span>To Be Implemented</span>
+            {isLoading || checkedInNumber === undefined ? (
+              <span className="loading loading-spinner"></span>
+            ) : loadingError ? (
+              <span className="font-bold text-red-400">Error loading number of checked in users</span>
+            ) : (
+              <span className="font-bold">{checkedInNumber?.toString()}</span>
+            )}
           </p>
         </div>
 


### PR DESCRIPTION
## Implemented Functionality

Implemented functionality that checks the number of checked-in users from the `BatchRegistry` smart contract.

## Description

The hook `useScaffoldReadContract` is used to read the state of `checkedInCounter` in the `BatchRegistry` smart contract.

To display the checked-in builders count:
- A spinner loader is shown while the data is loading.
- Once the data is successfully loaded, the count is displayed in white text.

![Loader Example](https://github.com/user-attachments/assets/4dacec1f-961d-4725-b085-e077f7734ad6)

![Loaded Data Example](https://github.com/user-attachments/assets/0302a410-02c5-4259-ac96-48b3cb108990)

## Related Issues

_Closes [#5](https://github.com/BuidlGuidl/batch7.buidlguidl.com/issues/5)_

Your ENS/address: ursulovic.eth
